### PR TITLE
Migrate to App Build Suite (ABS)

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,4 +1,7 @@
 replace-chart-version-with-git: true
+replace-app-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/azure-storageclasses
 destination: ./build
+catalog-base-url: https://giantswarm.github.io/default-catalog/
+giantswarm-validator-ignored-checks: C0001

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@5.12.1
+  architect: giantswarm/architect@6.11.0
 
 workflows:
   package-and-push-chart-on-tag:
     jobs:
     - architect/push-to-app-catalog:
         context: architect
+        executor: app-build-suite
         name: package and push azure-storageclasses chart
         app_catalog: default-catalog
         app_catalog_test: default-test-catalog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.11.0
+  architect: giantswarm/architect@6.14.0
 
 workflows:
   package-and-push-chart-on-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to App Build Suite (ABS).
+
 ## [0.1.0] - 2021-10-04
 
 ### Added

--- a/helm/azure-storageclasses/Chart.yaml
+++ b/helm/azure-storageclasses/Chart.yaml
@@ -1,9 +1,12 @@
-apiVersion: v1
-appVersion: [[ .Version ]]
-description: A Helm chart for azure-storageclasses
-engine: gotpl
-home: https://github.com/giantswarm/azure-storageclasses
+apiVersion: v2
 name: azure-storageclasses
+version: 0.2.0-dev
+appVersion: 0.2.0-dev
+description: A Helm chart for azure-storageclasses
+icon: https://s.giantswarm.io/app-icons/1/png/default-app-light.png
+home: https://github.com/giantswarm/azure-storageclasses
 sources:
 - https://github.com/giantswarm/azure-storageclasses
-version: [[ .Version ]]
+annotations:
+  application.giantswarm.io/team: "phoenix"
+  io.giantswarm.application.team: "phoenix"

--- a/helm/azure-storageclasses/templates/_helpers.tpl
+++ b/helm/azure-storageclasses/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels.common" -}}
+app.kubernetes.io/name: {{ include "name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "phoenix" | quote }}
+helm.sh/chart: {{ include "chart" . | quote }}
+{{- end -}}

--- a/helm/azure-storageclasses/values.schema.json
+++ b/helm/azure-storageclasses/values.schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        }
+    }
+}
+

--- a/helm/azure-storageclasses/values.yaml
+++ b/helm/azure-storageclasses/values.yaml
@@ -1,7 +1,3 @@
 # azure-storageclasses: This is set as a reasonable default, feel free to change.
 
 name: azure-storageclasses
-
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"


### PR DESCRIPTION
## Summary

This PR migrates the chart to use App Build Suite (ABS) for building and packaging.

## Changes

- Updated `.abs/main.yaml`:
  - Added `replace-app-version-with-git` and `catalog-base-url`
- Updated `.circleci/config.yml` to use `app-build-suite` executor
- Updated `Chart.yaml`:
  - Changed apiVersion to v2
  - Replaced `[[ .Version ]]` and `[[ .AppVersion ]]` placeholders with dev versions
  - Removed deprecated `engine: gotpl` field
  - Added icon and team annotation (`io.giantswarm.application.team`)
- Updated `values.yaml`:
  - Removed `project.branch` and `project.commit` placeholders
- Updated `CHANGELOG.md`

## Testing

- [ ] CI passes with ABS
